### PR TITLE
fix race conditions in ship movement

### DIFF
--- a/src/main/java/com/spencerseidel/JGGlob.java
+++ b/src/main/java/com/spencerseidel/JGGlob.java
@@ -16,6 +16,7 @@
 package com.spencerseidel;
 
 import java.awt.event.KeyEvent;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class JGGlob {
 
@@ -149,7 +150,7 @@ public class JGGlob {
 
   // These are stateful things that any game object
   // can change as game events happen
-  public static int                           direction;
+  public static AtomicInteger                 direction = new AtomicInteger(NOMOVE); // fixes issue #8
   public static boolean                       fire;
   public static int                           playerx;
   public static int                           numBadGuys;

--- a/src/main/java/com/spencerseidel/JGPlayerSprite.java
+++ b/src/main/java/com/spencerseidel/JGPlayerSprite.java
@@ -13,19 +13,19 @@ public class JGPlayerSprite extends JGSprite {
 	private static final int MOVEMENT_SPEED=(int)(5.0*JGGlob.SCALE);
 
 	public JGPlayerSprite(int x, int y, int w, int h, Image f[]) {
-		super(x, y, w, h, JGGlob.PLAYER_TYPE, f);	
+		super(x, y, w, h, JGGlob.PLAYER_TYPE, f);
 
 		JGGlob.playerAlive = true;
 	}
 
 	public void update() {
-		if (JGGlob.direction == JGGlob.MOVELEFT) {
+		if (JGGlob.direction.get() == JGGlob.MOVELEFT) {
 			locRect.x -= MOVEMENT_SPEED;
 			if (locRect.x < 0) {
 				locRect.x = 0;
 			}
 		}
-		else if (JGGlob.direction == JGGlob.MOVERIGHT) {
+		else if (JGGlob.direction.get() == JGGlob.MOVERIGHT) {
 			locRect.x += MOVEMENT_SPEED;
 			if (locRect.x > (JGGlob.SCREEN_WIDTH - locRect.width)) {
 				locRect.x = JGGlob.SCREEN_WIDTH - locRect.width;
@@ -35,7 +35,7 @@ public class JGPlayerSprite extends JGSprite {
 		// Update the bulletin board about where we are
 		JGGlob.playerx = locRect.x;
 	}
-	
+
 	public void died() {
 		JGGlob.playerAlive = false;
 	}

--- a/src/main/java/com/spencerseidel/JGalaxian.java
+++ b/src/main/java/com/spencerseidel/JGalaxian.java
@@ -995,11 +995,11 @@ public class JGalaxian extends JPanel implements KeyListener {
       switch (e.getKeyCode()) {
         case JGGlob.KEYLEFT1:
         case JGGlob.KEYLEFT2:
-          JGGlob.direction=JGGlob.MOVELEFT;
+          JGGlob.direction.set(JGGlob.MOVELEFT);
           break;
         case JGGlob.KEYRIGHT1:
         case JGGlob.KEYRIGHT2:
-          JGGlob.direction=JGGlob.MOVERIGHT;
+          JGGlob.direction.set(JGGlob.MOVERIGHT);
           break;
         case JGGlob.KEYFIRE1:
         case JGGlob.KEYFIRE2:
@@ -1036,11 +1036,15 @@ public class JGalaxian extends JPanel implements KeyListener {
     switch (e.getKeyCode()) {
       case JGGlob.KEYLEFT1:
       case JGGlob.KEYLEFT2:
-        JGGlob.direction=JGGlob.NOMOVE;
+        if(JGGlob.direction.get() == JGGlob.MOVELEFT) { // ony the release of the driving keypress should stop movement
+          JGGlob.direction.set(JGGlob.NOMOVE);
+        }
         break;
       case JGGlob.KEYRIGHT1:
       case JGGlob.KEYRIGHT2:
-        JGGlob.direction=JGGlob.NOMOVE;
+        if(JGGlob.direction.get() == JGGlob.MOVERIGHT) {
+          JGGlob.direction.set(JGGlob.NOMOVE);
+        }
         break;
       case JGGlob.KEYFIRE1:
       case JGGlob.KEYFIRE2:


### PR DESCRIPTION
Using an AtomicInteger to control player movement and checking to ensure that the stop movement condition only triggers when the key released matches the driving movement key. Fixes #8